### PR TITLE
Use a reasonable timeout

### DIFF
--- a/src/engineio_session.erl
+++ b/src/engineio_session.erl
@@ -20,7 +20,7 @@
 
 -include("engineio_internal.hrl").
 
--define(TIMEOUT_MS, 30000).
+-define(TIMEOUT_MS, 18000).
 
 %% API
 -export([start_link/6, init_mnesia/0, configure/1, create/6, find/1, pull/2, pull_no_wait/2, poll/1, safe_poll/1, recv/2,


### PR DESCRIPTION
We've seen work done by engineio_session objects take up to about 8s in the wild, and it doesn't break things, so use a timeout that will allow this and a bit more.

Note that the diff that is really of interest is from 6de594ce783d9da8d7c954d247347375e8c53ab6 to this one, as 6de594ce783d9da8d7c954d247347375e8c53ab6 is the one currently used by CW. You'll note that it introduces a timeout in a couple of places where there was none before, where the infinite atom is the default. I think this should be fine but we should see during load testing.